### PR TITLE
UPSTREAM: <carry>: Switch to UBI for builder image

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,8 +1,6 @@
-# TODO: Switch to UBI golang image when 1.17 is released
-# FROM registry.access.redhat.com/ubi8/go-toolset:latest AS builder
-FROM golang:1.17 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.16.12 AS builder
 
-WORKDIR /workspace
+WORKDIR /opt/app-root/src
 
 # Copy the dependencies which don't change frequently
 COPY go.mod go.mod
@@ -17,8 +15,8 @@ COPY pkg pkg
 COPY webhooks webhooks
 
 # Build the controller
-RUN go build -mod=vendor -o bin/controller main.go
+RUN go build -mod=vendor -o controller main.go
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-COPY --from=builder /workspace/bin/controller /usr/bin/controller
+COPY --from=builder /opt/app-root/src/controller /usr/bin/controller
 ENTRYPOINT ["/usr/bin/controller"]


### PR DESCRIPTION
The build image should use UBI.