### PR TITLE
Added EnableIPTargetType feature gate to controller

### DIFF
--- a/controllers/ingress/group_controller.go
+++ b/controllers/ingress/group_controller.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/aws-load-balancer-controller/controllers/ingress/eventhandlers"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/annotations"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/aws"
-	"sigs.k8s.io/aws-load-balancer-controller/pkg/config"
+	cfg "sigs.k8s.io/aws-load-balancer-controller/pkg/config"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy"
 	elbv2deploy "sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/elbv2"
 	"sigs.k8s.io/aws-load-balancer-controller/pkg/deploy/tracking"
@@ -44,7 +44,7 @@ const (
 func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder record.EventRecorder,
 	finalizerManager k8s.FinalizerManager, networkingSGManager networkingpkg.SecurityGroupManager,
 	networkingSGReconciler networkingpkg.SecurityGroupReconciler, subnetsResolver networkingpkg.SubnetsResolver,
-	config config.ControllerConfig, backendSGProvider networkingpkg.BackendSGProvider, logger logr.Logger) *groupReconciler {
+	config cfg.ControllerConfig, backendSGProvider networkingpkg.BackendSGProvider, logger logr.Logger) *groupReconciler {
 
 	annotationParser := annotations.NewSuffixAnnotationParser(annotations.AnnotationPrefixIngress)
 	authConfigBuilder := ingress.NewDefaultAuthConfigBuilder(annotationParser)
@@ -57,7 +57,7 @@ func NewGroupReconciler(cloud aws.Cloud, k8sClient client.Client, eventRecorder 
 		annotationParser, subnetsResolver,
 		authConfigBuilder, enhancedBackendBuilder, trackingProvider, elbv2TaggingManager,
 		cloud.VpcID(), config.ClusterName, config.DefaultTags, config.ExternalManagedTags,
-		config.DefaultSSLPolicy, backendSGProvider, config.EnableBackendSecurityGroup, config.DisableRestrictedSGRules, logger)
+		config.DefaultSSLPolicy, backendSGProvider, config.EnableBackendSecurityGroup, config.DisableRestrictedSGRules, config.FeatureGates.Enabled(cfg.EnableIPTargetType), logger)
 	stackMarshaller := deploy.NewDefaultStackMarshaller()
 	stackDeployer := deploy.NewDefaultStackDeployer(cloud, k8sClient, networkingSGManager, networkingSGReconciler,
 		config, ingressTagPrefix, logger)

--- a/docs/deploy/configurations.md
+++ b/docs/deploy/configurations.md
@@ -145,3 +145,4 @@ They are a set of kye=value pairs that describe AWS load balance controller feat
 | WeightedTargetGroups                  | string                          | true           | Enable or disable weighted target groups |
 | ServiceTypeLoadBalancerOnly           | string                          | false          | If enabled, controller will be limited to reconciling service of type `LoadBalancer`|
 | EnableServiceController               | string                          | true           | Toggles support for `Service` type resources. |
+| EnableIPTargetType                    | string                          | true           | Used to toggle support for target-type `ip` across `Ingress` and `Service` type resources. |

--- a/pkg/config/feature_gates.go
+++ b/pkg/config/feature_gates.go
@@ -15,6 +15,7 @@ const (
 	ServiceTypeLoadBalancerOnly Feature = "ServiceTypeLoadBalancerOnly"
 	EndpointsFailOpen           Feature = "EndpointsFailOpen"
 	EnableServiceController     Feature = "EnableServiceController"
+	EnableIPTargetType          Feature = "EnableIPTargetType"
 )
 
 type FeatureGates interface {
@@ -47,6 +48,7 @@ func NewFeatureGates() FeatureGates {
 			ServiceTypeLoadBalancerOnly: false,
 			EndpointsFailOpen:           false,
 			EnableServiceController:     true,
+			EnableIPTargetType:          true,
 		},
 	}
 }

--- a/pkg/ingress/model_build_target_group.go
+++ b/pkg/ingress/model_build_target_group.go
@@ -214,6 +214,9 @@ func (t *defaultModelBuildTask) buildTargetGroupTargetType(_ context.Context, sv
 	case string(elbv2model.TargetTypeInstance):
 		return elbv2model.TargetTypeInstance, nil
 	case string(elbv2model.TargetTypeIP):
+		if !t.enableIPTargetType {
+			return "", errors.Errorf("unsupported targetType: %v when EnableIPTargetType is %v", rawTargetType, t.enableIPTargetType)
+		}
 		return elbv2model.TargetTypeIP, nil
 	default:
 		return "", errors.Errorf("unknown targetType: %v", rawTargetType)

--- a/pkg/ingress/model_builder.go
+++ b/pkg/ingress/model_builder.go
@@ -40,7 +40,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 	authConfigBuilder AuthConfigBuilder, enhancedBackendBuilder EnhancedBackendBuilder,
 	trackingProvider tracking.Provider, elbv2TaggingManager elbv2deploy.TaggingManager,
 	vpcID string, clusterName string, defaultTags map[string]string, externalManagedTags []string, defaultSSLPolicy string,
-	backendSGProvider networkingpkg.BackendSGProvider, enableBackendSG bool, disableRestrictedSGRules bool, logger logr.Logger) *defaultModelBuilder {
+	backendSGProvider networkingpkg.BackendSGProvider, enableBackendSG bool, disableRestrictedSGRules bool, enableIPTargetType bool, logger logr.Logger) *defaultModelBuilder {
 	certDiscovery := NewACMCertDiscovery(acmClient, logger)
 	ruleOptimizer := NewDefaultRuleOptimizer(logger)
 	return &defaultModelBuilder{
@@ -63,6 +63,7 @@ func NewDefaultModelBuilder(k8sClient client.Client, eventRecorder record.EventR
 		defaultSSLPolicy:         defaultSSLPolicy,
 		enableBackendSG:          enableBackendSG,
 		disableRestrictedSGRules: disableRestrictedSGRules,
+		enableIPTargetType:       enableIPTargetType,
 		logger:                   logger,
 	}
 }
@@ -92,6 +93,7 @@ type defaultModelBuilder struct {
 	defaultSSLPolicy         string
 	enableBackendSG          bool
 	disableRestrictedSGRules bool
+	enableIPTargetType       bool
 
 	logger logr.Logger
 }
@@ -117,6 +119,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, ingGroup Group) (core.S
 		logger:                   b.logger,
 		enableBackendSG:          b.enableBackendSG,
 		disableRestrictedSGRules: b.disableRestrictedSGRules,
+		enableIPTargetType:       b.enableIPTargetType,
 
 		ingGroup: ingGroup,
 		stack:    stack,
@@ -172,6 +175,7 @@ type defaultModelBuildTask struct {
 	backendSGIDToken         core.StringToken
 	enableBackendSG          bool
 	disableRestrictedSGRules bool
+	enableIPTargetType       bool
 
 	defaultTags                               map[string]string
 	externalManagedTags                       sets.String

--- a/pkg/ingress/model_builder_test.go
+++ b/pkg/ingress/model_builder_test.go
@@ -194,12 +194,13 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 	}
 
 	tests := []struct {
-		name          string
-		env           env
-		args          args
-		fields        fields
-		wantStackJSON string
-		wantErr       error
+		name               string
+		env                env
+		enableIPTargetType *bool
+		args               args
+		fields             fields
+		wantStackJSON      string
+		wantErr            error
 	}{
 		{
 			name: "Ingress - vanilla internal",
@@ -3612,6 +3613,59 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 			wantErr: errors.New("ingress: ns-1/ing-1: unsupported IPv6 configuration, lb not dual-stack"),
 		},
 		{
+			name: "target type IP with enableIPTargetType set to false",
+			env: env{
+				svcs: []*corev1.Service{svcWithNamedTargetPort},
+			},
+			enableIPTargetType: awssdk.Bool(false),
+			fields: fields{
+				resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForInternalLB},
+				listLoadBalancersCalls:   []listLoadBalancersCall{listLoadBalancerCallForEmptyLB},
+				enableBackendSG:          true,
+			},
+			args: args{
+				ingGroup: Group{
+					ID: GroupID{Namespace: "ns-1", Name: "ing-1"},
+					Members: []ClassifiedIngress{
+						{
+							Ing: &networking.Ingress{ObjectMeta: metav1.ObjectMeta{
+								Namespace: "ns-1",
+								Name:      "ing-1",
+								Annotations: map[string]string{
+									"alb.ingress.kubernetes.io/target-type": "ip",
+								},
+							},
+								Spec: networking.IngressSpec{
+									Rules: []networking.IngressRule{
+										{
+											IngressRuleValue: networking.IngressRuleValue{
+												HTTP: &networking.HTTPIngressRuleValue{
+													Paths: []networking.HTTPIngressPath{
+														{
+															Path: "/",
+															Backend: networking.IngressBackend{
+																Service: &networking.IngressServiceBackend{
+																	Name: svcWithNamedTargetPort.Name,
+																	Port: networking.ServiceBackendPort{
+																		Name: "https",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: errors.New("ingress: ns-1/ing-1: unsupported targetType: ip when EnableIPTargetType is false"),
+		},
+		{
 			name: "target type IP with named target port",
 			env: env{
 				svcs: []*corev1.Service{svcWithNamedTargetPort},
@@ -3898,6 +3952,12 @@ func Test_defaultModelBuilder_Build(t *testing.T) {
 				logger:                 &log.NullLogger{},
 
 				defaultSSLPolicy: "ELBSecurityPolicy-2016-08",
+			}
+
+			if tt.enableIPTargetType == nil {
+				b.enableIPTargetType = true
+			} else {
+				b.enableIPTargetType = *tt.enableIPTargetType
 			}
 
 			gotStack, _, _, err := b.Build(context.Background(), tt.args.ingGroup)

--- a/pkg/service/model_build_target_group.go
+++ b/pkg/service/model_build_target_group.go
@@ -339,6 +339,9 @@ func (t *defaultModelBuildTask) buildTargetType(_ context.Context, port corev1.S
 	var lbTargetType string
 	lbTargetType = string(t.defaultTargetType)
 	_ = t.annotationParser.ParseStringAnnotation(annotations.SvcLBSuffixTargetType, &lbTargetType, t.service.Annotations)
+	if lbTargetType == LoadBalancerTargetTypeIP && !t.enableIPTargetType {
+		return "", errors.Errorf("unsupported targetType: %v when EnableIPTargetType is %v", lbTargetType, t.enableIPTargetType)
+	}
 	if lbType == LoadBalancerTypeNLBIP || lbTargetType == LoadBalancerTargetTypeIP {
 		return elbv2model.TargetTypeIP, nil
 	}

--- a/pkg/service/model_build_target_group_test.go
+++ b/pkg/service/model_build_target_group_test.go
@@ -1159,12 +1159,12 @@ func Test_defaultModelBuilder_buildPreserveClientIPFlag(t *testing.T) {
 }
 
 func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
-
 	tests := []struct {
-		testName string
-		svc      *corev1.Service
-		want     elbv2.TargetType
-		wantErr  error
+		testName           string
+		svc                *corev1.Service
+		want               elbv2.TargetType
+		enableIPTargetType *bool
+		wantErr            error
 	}{
 		{
 			testName: "empty annotation",
@@ -1246,6 +1246,29 @@ func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 				},
 			},
 			want: elbv2.TargetTypeIP,
+		},
+		{
+			testName: "enableIPTargetType is false, target ip",
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Name:       "http",
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			enableIPTargetType: aws.Bool(false),
+			wantErr:            errors.New("unsupported targetType: ip when EnableIPTargetType is false"),
 		},
 		{
 			testName: "external, ClusterIP with target type instance",
@@ -1336,6 +1359,11 @@ func Test_defaultModelBuilder_buildTargetType(t *testing.T) {
 				annotationParser:  parser,
 				service:           tt.svc,
 				defaultTargetType: LoadBalancerTargetTypeInstance,
+			}
+			if tt.enableIPTargetType == nil {
+				builder.enableIPTargetType = true
+			} else {
+				builder.enableIPTargetType = *tt.enableIPTargetType
 			}
 			got, err := builder.buildTargetType(context.Background(), tt.svc.Spec.Ports[0])
 			if tt.wantErr != nil {

--- a/pkg/service/model_builder.go
+++ b/pkg/service/model_builder.go
@@ -36,7 +36,7 @@ type ModelBuilder interface {
 func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver networking.SubnetsResolver,
 	vpcInfoProvider networking.VPCInfoProvider, vpcID string, trackingProvider tracking.Provider,
 	elbv2TaggingManager elbv2deploy.TaggingManager, clusterName string, defaultTags map[string]string,
-	externalManagedTags []string, defaultSSLPolicy string, serviceUtils ServiceUtils) *defaultModelBuilder {
+	externalManagedTags []string, defaultSSLPolicy string, enableIPTargetType bool, serviceUtils ServiceUtils) *defaultModelBuilder {
 	return &defaultModelBuilder{
 		annotationParser:    annotationParser,
 		subnetsResolver:     subnetsResolver,
@@ -49,6 +49,7 @@ func NewDefaultModelBuilder(annotationParser annotations.Parser, subnetsResolver
 		defaultTags:         defaultTags,
 		externalManagedTags: sets.NewString(externalManagedTags...),
 		defaultSSLPolicy:    defaultSSLPolicy,
+		enableIPTargetType:  enableIPTargetType,
 	}
 }
 
@@ -67,6 +68,7 @@ type defaultModelBuilder struct {
 	defaultTags         map[string]string
 	externalManagedTags sets.String
 	defaultSSLPolicy    string
+	enableIPTargetType  bool
 }
 
 func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service) (core.Stack, *elbv2model.LoadBalancer, error) {
@@ -80,6 +82,7 @@ func (b *defaultModelBuilder) Build(ctx context.Context, service *corev1.Service
 		trackingProvider:    b.trackingProvider,
 		elbv2TaggingManager: b.elbv2TaggingManager,
 		serviceUtils:        b.serviceUtils,
+		enableIPTargetType:  b.enableIPTargetType,
 
 		service:   service,
 		stack:     stack,
@@ -129,6 +132,7 @@ type defaultModelBuildTask struct {
 	trackingProvider    tracking.Provider
 	elbv2TaggingManager elbv2deploy.TaggingManager
 	serviceUtils        ServiceUtils
+	enableIPTargetType  bool
 
 	service *corev1.Service
 

--- a/pkg/service/model_builder_test.go
+++ b/pkg/service/model_builder_test.go
@@ -101,6 +101,7 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 		resolveViaNameOrIDSliceCalls []resolveViaNameOrIDSliceCall
 		listLoadBalancerCalls        []listLoadBalancerCall
 		fetchVPCInfoCalls            []fetchVPCInfoCall
+		enableIPTargetType           *bool
 		svc                          *corev1.Service
 		wantError                    bool
 		wantValue                    string
@@ -1961,6 +1962,36 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 `,
 		},
 		{
+			testName:           "service with enableIPTargetType set to false and type IP",
+			enableIPTargetType: aws.Bool(false),
+			svc: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "traffic-local",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"service.beta.kubernetes.io/aws-load-balancer-type":            "external",
+						"service.beta.kubernetes.io/aws-load-balancer-nlb-target-type": "ip",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Type:       corev1.ServiceTypeLoadBalancer,
+					Selector:   map[string]string{"app": "hello"},
+					IPFamilies: []corev1.IPFamily{corev1.IPv6Protocol},
+					Ports: []corev1.ServicePort{
+						{
+							Port:       80,
+							TargetPort: intstr.FromInt(80),
+							Protocol:   corev1.ProtocolTCP,
+							NodePort:   32332,
+						},
+					},
+				},
+			},
+			resolveViaDiscoveryCalls: []resolveViaDiscoveryCall{resolveViaDiscoveryCallForOneSubnet},
+			listLoadBalancerCalls:    []listLoadBalancerCall{listLoadBalancerCallForEmptyLB},
+			wantError:                true,
+		},
+		{
 			testName: "list load balancers error",
 			svc: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2733,8 +2764,14 @@ func Test_defaultModelBuilderTask_Build(t *testing.T) {
 				vpcInfoProvider.EXPECT().FetchVPCInfo(gomock.Any(), gomock.Any(), gomock.Any()).Return(call.wantVPCInfo, call.err).AnyTimes()
 			}
 			serviceUtils := NewServiceUtils(annotationParser, "service.k8s.aws/resources", "service.k8s.aws/nlb", featureGates)
+			var enableIPTargetType bool
+			if tt.enableIPTargetType == nil {
+				enableIPTargetType = true
+			} else {
+				enableIPTargetType = *tt.enableIPTargetType
+			}
 			builder := NewDefaultModelBuilder(annotationParser, subnetsResolver, vpcInfoProvider, "vpc-xxx", trackingProvider, elbv2TaggingManager,
-				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", serviceUtils)
+				"my-cluster", nil, nil, "ELBSecurityPolicy-2016-08", enableIPTargetType, serviceUtils)
 			ctx := context.Background()
 			stack, _, err := builder.Build(ctx, tt.svc)
 			if tt.wantError {


### PR DESCRIPTION
Signed-off-by: thejasn <thn@redhat.com>

### Issue

Fixes: #2559 

### Description

Added a controller flag to toggle AWS VPC CNI dependent features. Currently, can be used to enforce the correct `target-type` annotation on `Ingress` type resources.

-->

### Checklist
- [ ] Added tests that cover your change (if possible)
- [x] Added/modified documentation as required (such as the `README.md`, or the `docs` directory)
- [x] Manually tested
- [x] Made sure the title of the PR is a good description that can go into the release notes

### BONUS POINTS checklist: complete for good vibes and maybe prizes?! :exploding_head:
- [ ] Backfilled missing tests for code in same general area :tada:
- [ ] Refactored something and made the world a better place :star2:
