### PR TITLE
OCPBUGS-14846: webhook - set minimum TLS version back to 1.2 to support FIPS clusters

### DIFF
--- a/pkg/config/runtime_config.go
+++ b/pkg/config/runtime_config.go
@@ -131,5 +131,5 @@ func BuildRuntimeOptions(rtCfg RuntimeConfig, scheme *runtime.Scheme) ctrl.Optio
 func ConfigureWebhookServer(rtCfg RuntimeConfig, mgr ctrl.Manager) {
 	mgr.GetWebhookServer().CertName = rtCfg.WebhookCertName
 	mgr.GetWebhookServer().KeyName = rtCfg.WebhookKeyName
-	mgr.GetWebhookServer().TLSMinVersion = "1.3"
+	mgr.GetWebhookServer().TLSMinVersion = "1.2"
 }


### PR DESCRIPTION
The goal of this PR is to support environments where TLS versions 1.2 is still used, mainly FIPS enabled systems. The boringcrypto enabled builds check for the maximum FIPS TLS version [which is set to TLS1.2](https://github.com/golang/go/blob/0184fe5ece4f84fda9db04d2472b76efcaa8ef55/src/crypto/tls/boring.go#L24-L28).

Initial upstream PR: https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3313
Upstream follow-up PR: https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3318

**Note**
https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3318 uses `TLSOpts` of the webhook server, it's a feature which is available in controller-runtime `0.14.x`. The currently used controller-runtime doesn't have it, so we cannot specify ciphers (as [the upstream PR](https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/3318/files) did), only the minimum TLS version.

**Test**
Operator e2e (not FIPS): https://github.com/openshift/aws-load-balancer-operator/pull/99
Manual test (FIPS):
```
# controller is there
$ oc -n aws-load-balancer-operator get pods
NAME                                                             READY   STATUS    RESTARTS   AGE
aws-load-balancer-controller-cluster-fcbc7bbdb-7rnx4             1/1     Running   0          2m19s
aws-load-balancer-operator-controller-manager-85d94d56c5-mjpq6   2/2     Running   0          5m11s

# it uses a manually built image (same as in the operator PR, see above)
$ oc -n aws-load-balancer-operator get pods aws-load-balancer-controller-cluster-fcbc7bbdb-7rnx4 -o yaml | yq .spec.containers[0].image
quay.io/aws-load-balancer-operator/aws-load-balancer-controller:8.10.234-tls12

# ingress webhook is on
$ oc -n aws-load-balancer-operator logs aws-load-balancer-controller-cluster-fcbc7bbdb-7rnx4 | grep 'webhook.*ingress'
{"level":"info","ts":1691706492.4913087,"logger":"controller-runtime.webhook","msg":"registering webhook","path":"/validate-networking-v1-ingress"}

# ingress resource got created with no TLS errors
$ oc -n echoserver get ing
NAME         CLASS   HOSTS   ADDRESS                                                                   PORTS   AGE
echoserver   alb     *       k8s-echoserv-echoserv-314d49d2d2-1425878010.us-east-1.elb.amazonaws.com   80      42s
```