### PR TITLE
UPSTREAM <carry>: OCPBUGS-24653: Ensure FIPS compliance for controller image

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -15,8 +15,8 @@ COPY pkg pkg
 COPY webhooks webhooks
 
 # Build the controller
-RUN go build -mod=vendor -o controller main.go
+RUN go build -tags strictfipsruntime -mod=vendor -o controller main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.redhat.io/rhel8-6-els/rhel:latest
 COPY --from=builder /opt/app-root/src/controller /usr/bin/controller
 ENTRYPOINT ["/usr/bin/controller"]


### PR DESCRIPTION
- Replaced the base image with a non-UBI variant.
- Added the 'strictfipsruntime' tag to the controller binary.

`check-payload` scan:
```
$ git log -1
commit b84e919edb49f66ee1b3f538490f3d756c5edc42 (HEAD -> fips-compliance, origin/fips-compliance)
Author: Andrey Lebedev <alebedev@redhat.com>
Date:   Wed Apr 3 12:12:41 2024 +0200

    UPSTREAM <carry>: OCPBUGS-24653: Ensure FIPS compliance for controller image
    
    - Replaced the base image with a non-UBI variant.
    - Added the 'strictfipsruntime' tag to the controller binary.

$ podman build -t quay.io/alebedev/aws-load-balancer-controller:b84e919ed -f Dockerfile.openshift .
...
Successfully tagged quay.io/alebedev/aws-load-balancer-controller:b84e919ed
Successfully tagged quay.io/alebedev/aws-load-balancer-controller:3.4.1140
015b97227b263e93e08c9265b0cc9007c30d8c569591c0437e16df3069c894f7

$ podman push quay.io/alebedev/aws-load-balancer-controller:b84e919ed
Getting image source signatures
Copying blob 013e3dbc52ff skipped: already exists  
Copying blob fc72b3d90f88 skipped: already exists  
Copying config 015b97227b done  
Writing manifest to image destination

$ podman run --privileged registry.ci.openshift.org/ci/check-payload:latest scan operator --spec quay.io/alebedev/aws-load-balancer-controller:b84e919ed
I0403 10:32:34.093944       1 main.go:302] using embedded config
I0403 10:32:34.094271       1 types_config.go:12] using config ...
I0403 10:32:34.094342       1 main.go:102] "scan" version="0.3.1-91-ga0d1e0d3-dirty"
---- Successful run
```