### PR TITLE
NE-2064: Add dedicated Containerfile for Konflux builds

### DIFF
--- a/Containerfile.aws-load-balancer-controller
+++ b/Containerfile.aws-load-balancer-controller
@@ -1,0 +1,31 @@
+# Detect the drift from the upstream Dockerfile
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS drift
+WORKDIR /app
+COPY drift-cache/Dockerfile.openshift Dockerfile.openshift.cached
+COPY Dockerfile.openshift .
+# If the command below fails it means that the Dockerfile.openshift from this repository changed.
+# You have to update the Konflux Containerfile accordingly (Containerfile.aws-load-balancer-controller).
+# drift-cache/Dockerfile.openshift.cached can be updated with the source contents once the Konflux version is aligned.
+RUN [ "$(sha1sum Dockerfile.openshift.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile.openshift | cut -d' ' -f1)" ]
+
+FROM registry.access.redhat.com/ubi8/go-toolset:1.22 as builder
+# dummy copy to trigger the drift detection
+COPY --from=drift /app/Dockerfile.openshift.cached .
+
+COPY . /workspace
+WORKDIR /workspace
+
+# Build
+RUN go build -tags strictfipsruntime -o /usr/bin/controller -mod=vendor main.go
+
+FROM registry.redhat.io/rhel8-6-els/rhel:8.6-1737
+LABEL maintainer="Red Hat, Inc."
+LABEL com.redhat.component="aws-load-balancer-controller-container"
+LABEL name="aws-load-balancer-controller"
+LABEL version="1.2.0"
+LABEL commit="d58fdf6a6b049d6dd779435364f6fb238d1aa755"
+
+WORKDIR /
+COPY --from=builder /usr/bin/controller /
+
+ENTRYPOINT ["/controller"]

--- a/drift-cache/Dockerfile.openshift
+++ b/drift-cache/Dockerfile.openshift
@@ -1,0 +1,22 @@
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS builder
+
+WORKDIR /opt/app-root/src
+
+# Copy the dependencies which don't change frequently
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor vendor
+
+# Copy the source files
+COPY apis apis
+COPY main.go main.go
+COPY controllers controllers
+COPY pkg pkg
+COPY webhooks webhooks
+
+# Build the controller
+RUN go build -tags strictfipsruntime -mod=vendor -o controller main.go
+
+FROM registry.redhat.io/rhel8-6-els/rhel:latest
+COPY --from=builder /opt/app-root/src/controller /usr/bin/controller
+ENTRYPOINT ["/usr/bin/controller"]


### PR DESCRIPTION
This PR adds a dedicated Containerfile that can be referenced by the Konflux operator component. It automatically detects drift from the `Dockerfile.opemshift`, thereby enforcing synchronization between the version used in CI presubmits and Konflux.

The base image used matches the minor version that was in use in CPaaS at the time the migration to Konflux began. This ensures continuity with previous releases.

The builder image, on the other hand, has been set to `registry.access.redhat.com/ubi8/go-toolset` to avoid relying on `registry-proxy.engineering.redhat.com` (used in CPaaS) and to stay consistent with the builder image samples recommended by the Konflux migration team.

Reference Dockerfile from CPaaS: [link](https://gitlab.cee.redhat.com/cpaas-midstream/aws-load-balancer-operator/-/blob/aws-lb-optr-1.2-rhel-8/distgit/containers/aws-load-balancer-controller/Dockerfile.in?ref_type=heads).