### PR TITLE
NE-2064: UPSTREAM: <carry>: Add non-root user and licences to Containerfile

### DIFF
--- a/Containerfile.aws-load-balancer-controller
+++ b/Containerfile.aws-load-balancer-controller
@@ -34,5 +34,6 @@ LABEL commit="d58fdf6a6b049d6dd779435364f6fb238d1aa755"
 
 WORKDIR /
 COPY --from=builder /workspace/controller /
-
+COPY LICENSE /licenses/
+USER 65532:65532
 ENTRYPOINT ["/controller"]


### PR DESCRIPTION
Add `USER` instruction with non-root id to the main stage of Containerfile to comply with Red Hat certified image requirements.
Add `LICENSE` to `/licenses/` to comply with Red Hat certified image requirements


Knowledge base article on Image Content Requirements: [link](https://docs.redhat.com/en/documentation/red_hat_software_certification/2025/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction).
