### PR TITLE
NE-2074: UPSTREAM: <carry>: Disable Konflux Go module updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "gomod": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
Disable automatic updates of Go dependencies made by MintMaker in Konflux. This is to prevent conflicts during rebases. Going forward, Go dependencies will only be updated through upstream rebases.