### PR TITLE
OCPBUGS-46442: UPSTREAM: <carry>: Use UBI9 for base and builder openshift images

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.22-openshift-4.17
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 
 WORKDIR /opt/app-root/src
 
@@ -17,6 +17,6 @@ COPY webhooks webhooks
 # Build the controller
 RUN go build -tags strictfipsruntime -mod=vendor -o controller main.go
 
-FROM registry.redhat.io/rhel8-6-els/rhel:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 COPY --from=builder /opt/app-root/src/controller /usr/bin/controller
 ENTRYPOINT ["/usr/bin/controller"]

--- a/drift-cache/Dockerfile.openshift
+++ b/drift-cache/Dockerfile.openshift
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.22-openshift-4.17 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 AS builder
 
 WORKDIR /opt/app-root/src
 
@@ -17,6 +17,6 @@ COPY webhooks webhooks
 # Build the controller
 RUN go build -tags strictfipsruntime -mod=vendor -o controller main.go
 
-FROM registry.redhat.io/rhel8-6-els/rhel:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 COPY --from=builder /opt/app-root/src/controller /usr/bin/controller
 ENTRYPOINT ["/usr/bin/controller"]


### PR DESCRIPTION
Change RHEL8 builder and base image to UBI9.

UBI9 enables to retain FIPS compliance as well and it is the image that is going to be used for the Konflux built component.