### PR TITLE
NE-2064: UPSTREAM: <carry>: Containerfile: Update base image to UBI9

### DIFF
--- a/Containerfile.aws-load-balancer-controller
+++ b/Containerfile.aws-load-balancer-controller
@@ -1,14 +1,14 @@
 # Detect the drift from the upstream Dockerfile
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS drift
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS drift
 WORKDIR /app
 COPY drift-cache/Dockerfile.openshift Dockerfile.openshift.cached
 COPY Dockerfile.openshift .
 # If the command below fails it means that the Dockerfile.openshift from this repository changed.
 # You have to update the Konflux Containerfile accordingly (Containerfile.aws-load-balancer-controller).
 # drift-cache/Dockerfile.openshift.cached can be updated with the source contents once the Konflux version is aligned.
-RUN [ "$(sha1sum Dockerfile.openshift.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile.openshift | cut -d' ' -f1)" ]
+RUN test "$(sha1sum Dockerfile.openshift.cached | cut -d' ' -f1)" = "$(sha1sum Dockerfile.openshift | cut -d' ' -f1)"
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.22 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22 as builder
 # dummy copy to trigger the drift detection
 COPY --from=drift /app/Dockerfile.openshift.cached .
 
@@ -25,7 +25,7 @@ COPY . .
 # Build
 RUN go build -tags strictfipsruntime -o controller -mod=vendor main.go
 
-FROM registry.redhat.io/rhel8-6-els/rhel:8.6-1737
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1751287003
 LABEL maintainer="Red Hat, Inc."
 LABEL com.redhat.component="aws-load-balancer-controller-container"
 LABEL name="aws-load-balancer-controller"


### PR DESCRIPTION
The RHEL ELS image had limited use and was previously chosen because UBI was not FIPS-ready. Now, UBI is the recommended base image for all customer-facing container images. It is also the most popular base image in Konflux.

This also bumps from RHEL8 to UBI9 to avoid fixable vulnerabilities from UBI8.

* Containerfile.aws-load-balancer-controller:
Update builder and base images to ubi9.
Use test bash builtin instead of [] as a workaround to [PSSECAUT-1207](https://issues.redhat.com/browse/PSSECAUT-1207)