### PR TITLE
NE-2074: UPSTREAM: <carry>: Configure Renovate updates of images, go-toolset and CVEs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,54 @@
 {
-  "gomod": {
-    "enabled": false
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabledManagers": ["dockerfile", "gomod"],
+  "commitMessagePrefix": "UPSTREAM: <carry>: ",
+  "packageRules": [
+    {
+      "description": "Disable all Dockerfile updates by default. Only specific files will get targeted.",
+      "matchManagers": ["dockerfile"],
+      "enabled": false
+    },
+    {
+      "description": "Enable Docker image updates for Red Hat UBI images on major version 9 only in OpenShift files",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": [
+        "Containerfile.aws-load-balancer-controller",
+        "Dockerfile.openshift",
+        "drift-cache/Dockerfile.openshift"
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi9/ubi-minimal",
+        "registry.access.redhat.com/ubi9/ubi"
+      ],
+      "enabled": true,
+      "versioning": "redhat",
+      "allowedVersions": "/^9(\\.|$)/"
+    },
+    {
+      "description": "Keep Go toolset on minor version 1.22 only in OpenShift files",
+      "matchManagers": ["dockerfile"],
+      "matchFileNames": [
+        "Containerfile.aws-load-balancer-controller",
+        "Dockerfile.openshift",
+        "drift-cache/Dockerfile.openshift"
+      ],
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "registry.access.redhat.com/ubi9/go-toolset"
+      ],
+      "enabled": true,
+      "versioning": "redhat",
+      "allowedVersions": "/^1\\.22(\\.|$)/"
+    },
+    {
+      "description": "Disable regular Go module updates, only allow vulnerability alerts",
+      "matchManagers": ["gomod"],
+      "enabled": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
   },
-  "commitMessagePrefix": "UPSTREAM: <carry>: "
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
Add Renovate configuration which:

- Configures base and builder images updates to be restricted within the major version 9 only.
- Go version updates restricted to be within the minor version 1.22.
- Disables go module updates except for CVE related ones.

Explicitly uses only `gomod` and `dockerfile` dependency managers for the above, as the other updates would be carried from upstream.