### PR TITLE
NE-2074: UPSTREAM: <carry>: Enable Konflux dependencies updates, disable gomod bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": ["dockerfile", "gomod"],
+  "enabledManagers": ["dockerfile", "tekton"],
   "commitMessagePrefix": "UPSTREAM: <carry>: ",
   "packageRules": [
     {
@@ -9,12 +9,10 @@
       "enabled": false
     },
     {
-      "description": "Enable Docker image updates for Red Hat UBI images on major version 9 only in OpenShift files",
+      "description": "Enable Docker image updates for Red Hat UBI images on major version 9 in Containerfile only.",
       "matchManagers": ["dockerfile"],
       "matchFileNames": [
-        "Containerfile.aws-load-balancer-controller",
-        "Dockerfile.openshift",
-        "drift-cache/Dockerfile.openshift"
+        "Containerfile.aws-load-balancer-controller"
       ],
       "matchDatasources": ["docker"],
       "matchPackageNames": [
@@ -23,15 +21,16 @@
       ],
       "enabled": true,
       "versioning": "redhat",
-      "allowedVersions": "/^9(\\.|$)/"
+      "allowedVersions": "/^9(\\.|$)/",
+      "schedule": [
+        "after 5am on tuesday"
+      ]
     },
     {
-      "description": "Keep Go toolset on minor version 1.22 only in OpenShift files",
+      "description": "Keep Go toolset on minor version 1.22 in Containerfile only.",
       "matchManagers": ["dockerfile"],
       "matchFileNames": [
-        "Containerfile.aws-load-balancer-controller",
-        "Dockerfile.openshift",
-        "drift-cache/Dockerfile.openshift"
+        "Containerfile.aws-load-balancer-controller"
       ],
       "matchDatasources": ["docker"],
       "matchPackageNames": [
@@ -39,16 +38,58 @@
       ],
       "enabled": true,
       "versioning": "redhat",
-      "allowedVersions": "/^1\\.22(\\.|$)/"
-    },
-    {
-      "description": "Disable regular Go module updates, only allow vulnerability alerts",
-      "matchManagers": ["gomod"],
-      "enabled": false
+      "allowedVersions": "/^1\\.22(\\.|$)/",
+      "schedule": [
+        "after 5am on tuesday"
+      ]
     }
   ],
-  "vulnerabilityAlerts": {
-    "enabled": true
-  },
-  "osvVulnerabilityAlerts": true
+  "tekton": {
+    "managerFilePatterns": [
+      "/\\.yaml$/",
+      "/\\.yml$/"
+    ],
+    "includePaths": [
+      ".tekton/**"
+    ],
+    "packageRules": [
+      {
+        "matchPackageNames": [
+          "/^quay.io/redhat-appstudio-tekton-catalog//",
+          "/^quay.io/konflux-ci/tekton-catalog//",
+          "/^quay.io/konflux-ci/konflux-vanguard//"
+        ],
+        "enabled": true,
+        "groupName": "Konflux references",
+        "branchPrefix": "konflux/references/",
+        "additionalBranchPrefix": "",
+        "group": {
+          "branchTopic": "{{{baseBranch}}}",
+          "commitMessageTopic": "{{{groupName}}}"
+        },
+        "commitMessageTopic": "Konflux references",
+        "prBodyColumns": [
+          "Package",
+          "Change",
+          "Notes"
+        ],
+        "prBodyDefinitions": {
+          "Notes": "{{#if (or (containsString updateType 'minor') (containsString updateType 'major'))}}:warning:[migration](https://github.com/redhat-appstudio/build-definitions/blob/main/task/{{{replace '^quay.io/(redhat-appstudio-tekton-catalog|konflux-ci/tekton-catalog)/task-' '' packageName}}}/{{{newVersion}}}/MIGRATION.md):warning:{{/if}}"
+        },
+        "prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
+        "recreateWhen": "always",
+        "rebaseWhen": "behind-base-branch"
+      }
+    ],
+    "schedule": [
+      "after 5am on tuesday"
+    ],
+    "postUpgradeTasks": {
+      "commands": [
+        "pipeline-migration-tool migrate -f \"$RENOVATE_POST_UPGRADE_COMMAND_DATA_FILE\""
+      ],
+      "executionMode": "branch",
+      "dataFileTemplate": "[{{#each upgrades}}{\"depName\": \"{{{depName}}}\", \"currentValue\": \"{{{currentValue}}}\", \"currentDigest\": \"{{{currentDigest}}}\", \"newValue\": \"{{{newValue}}}\", \"newDigest\": \"{{{newDigest}}}\", \"packageFile\": \"{{{packageFile}}}\", \"parentDir\": \"{{{parentDir}}}\", \"depTypes\": [{{#each depTypes}}\"{{{this}}}\"{{#unless @last}},{{\/unless}}{{\/each}}]}{{#unless @last}},{{\/unless}}{{\/each}}]"
+    }
+  }
 }


### PR DESCRIPTION
- Add weekly Konflux dependencies updates grouped into a single PR.
- Add weekly schedule for Containerfile images updates.
- Disable all gomod bump PRs to avoid the unnecessary noise. The automated updates were found to be failing the build too often to be considered useful.

Konflux dependencies updates configuration was taken from [konflux-ci/mintmaker/config/renovate
/renovate.json](https://github.com/konflux-ci/mintmaker/blob/5f632ab7a9aabdff16092cc05127995c37c81d94/config/renovate/renovate.json#L70-L116)

One difference is that updates to `quay.io/konflux-ci/konflux-vanguard` were also added to be grouped into a single PR. The source config only groups together the updates to: `quay.io/konflux-ci/tekton-catalog` and `quay.io/redhat-appstudio-tekton-catalog`.