### PR TITLE
UPSTREAM: <carry>: NE-2063: Add bundle nudging konflux configuration

### DIFF
--- a/.tekton/aws-load-balancer-controller-container-aws-lb-optr-1-2-rhel-9-push.yaml
+++ b/.tekton/aws-load-balancer-controller-container-aws-lb-optr-1-2-rhel-9-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: bundle-hack/container_digest.sh
     build.appstudio.openshift.io/repo: https://github.com/openshift/aws-load-balancer-controller?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
Nudging allows to create dependencies between konflux components.
The nudging relationships between components are defined in the Konflux cluster.

This PR ensures that once a new controller image is built, konflux will automatically create a PR to update the operator digest located in `bundle-hack/container_digest.sh` in the `aws-load-balancer-operator` repository.
Sample [PR](https://github.com/konflux-ci/olm-operator-konflux-sample/pull/112).