### PR TITLE
NO-JIRA: UPSTREAM: <carry>: Add v1.3 tekton pipeline customization

### DIFF
--- a/.tekton/aws-load-balancer-controller-container-aws-lb-optr-1-3-rhel-9-push.yaml
+++ b/.tekton/aws-load-balancer-controller-container-aws-lb-optr-1-3-rhel-9-push.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: PipelineRun
 metadata:
   annotations:
+    build.appstudio.openshift.io/build-nudge-files: bundle-hack/container_digest.sh
     build.appstudio.openshift.io/repo: https://github.com/openshift/aws-load-balancer-controller?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'


### PR DESCRIPTION
After adding a new [Konflux Component ](https://gitlab.cee.redhat.com/releng/konflux-release-data/-/merge_requests/10452/diffs?commit_id=52d557a68be4f24573de1d72b1c10c16666e4b22)for the new v1.3 release and in consequence a new tekton pipeline in #66, the customizations to the pipelines which we had in v1.2 need to be added back to the automatically created pipeline. 

Currently there is only one customization that we need to carry forward:
- Add configuration which ensures that once a new controller image is built, konflux will automatically create a PR to update the image digest located in [bundle-hack/container_digest.sh](https://github.com/openshift/aws-load-balancer-operator/blob/main/bundle-hack/container_digest.sh) in aws-load-balancer-operator repository.